### PR TITLE
Remove Noob Trap that Personal Lights are

### DIFF
--- a/Ruleset/Soldiers_and_Armors_UNEXCOM.rul
+++ b/Ruleset/Soldiers_and_Armors_UNEXCOM.rul
@@ -487,6 +487,7 @@ armors:
       - 1.1
     units:
       - STR_SOLDIER
+    personalLight: 6
 
   - type: STR_PILOT_UC
     spriteSheet: PILOT.PCK
@@ -521,6 +522,7 @@ armors:
       - 1.1
     units:
       - STR_PILOT
+    personalLight: 6
 
   - type: STR_SPECIAL_FORCES_UNIFORM_UC
     spriteSheet: XCOM_4SF.PCK
@@ -564,6 +566,7 @@ armors:
       - 1.1
     units:
       - STR_SPECIAL_FORCES_SOLDIER
+    personalLight: 6
 
   - type: STR_MERCENARY_UNIFORM_UC
     spriteSheet: XCOM_4MERC.PCK
@@ -607,7 +610,7 @@ armors:
       - 1.1
     units:
       - STR_MERCENARY
-
+    personalLight: 6
 
   - type: STR_COMBAT_ARMOR_UC
     spriteSheet: XCOM_4UN.PCK
@@ -647,6 +650,7 @@ armors:
       - 0.8
       - 0.7
       - 1.0
+    personalLight: 6
 
   - type: STR_DELTA_ARMOR_UC
     spriteSheet: ARMOR_DELTA.PCK
@@ -656,7 +660,6 @@ armors:
       - STR_CORPSE_DELTA_ARMOR
     storeItem: STR_DELTA_ARMOR_UC
     corpseGeo: STR_CORPSE_DELTA_ARMOR
-    personalLight: 7
     weight: 15
     stats:
        stamina: -10
@@ -690,6 +693,7 @@ armors:
     forcedTorso: 1
     builtInWeapons:
       - STR_MG3
+    personalLight: 6
 
   - type: STR_RIOT_ARMOR_UC
     spriteSheet: ARMOR_RIOT.PCK
@@ -699,7 +703,6 @@ armors:
       - STR_CORPSE_RIOT_ARMOR
     corpseGeo: STR_CORPSE_RIOT_ARMOR
     storeItem: STR_RIOT_ARMOR_UC
-    personalLight: 5
     weight: 12
     stats:
        stamina: -5
@@ -736,6 +739,7 @@ armors:
     forcedTorso: 1
     builtInWeapons:
       - STR_RIOT_SHIELD
+    personalLight: 6
 
 # Standard Armors
   - type: STR_PERSONAL_ARMOR_UC
@@ -772,6 +776,8 @@ armors:
       - 0.80
       - 0.95
       - 1.0
+    personalLight: 6
+
   - type: STR_HEAVY_PERSONAL_ARMOR_UC
     spriteSheet: HEAVY_PERSONAL_ARMOR.PCK
     spriteInv: HEAVY_PERSONAL_ARMOR_INV
@@ -807,6 +813,7 @@ armors:
       - 0.75
       - 0.92
       - 1.0
+    personalLight: 6
 #Power Armors
 
 # Standard Armors
@@ -844,6 +851,8 @@ armors:
       - 0.70
       - 0.85
       - 0.0
+    personalLight: 6
+
   - type: STR_FLYING_SUIT_UC
     spriteSheet: PATHFINDER_SPRITESHEET.PCK
     spriteInv: MAN_PATHFINDER
@@ -879,6 +888,8 @@ armors:
       - 0.73
       - 0.88
       - 0.0
+    personalLight: 6
+
 # New Armors
   - type: STR_SCOUT_POWER_ARMOR_UC
     spriteSheet: SCOUT_POWER_ARMOR.PCK
@@ -915,6 +926,8 @@ armors:
       - 0.73
       - 0.88
       - 0.0
+    personalLight: 6
+
   - type: STR_SCOUT_FLYING_ARMOR_UC
     spriteSheet: SCOUT_FLYING_ARMOR.PCK
     spriteInv: SCOUT_FLYING_ARMOR_INV
@@ -950,6 +963,7 @@ armors:
       - 0.77
       - 0.90
       - 0.0
+    personalLight: 6
 
 #Astronaut Armors
 
@@ -969,7 +983,6 @@ armors:
     movementType: 0
     visibilityAtDark: 7
     visibilityAtDay: 26
-    personalLight: 10
     requires:
       STR_OLYMPUS
     stats: &EarthStats
@@ -991,6 +1004,7 @@ armors:
       - 1.0
       - 1.0
       - 0.0
+    personalLight: 6
 
   - &A7MMUSpacesuitAnchor
     type: STR_ASTRONAUT_A7_MMU_SPACESUIT_UC
@@ -1008,7 +1022,6 @@ armors:
     movementType: 1
     visibilityAtDark: 7
     visibilityAtDay: 26
-    personalLight: 10
     requires:
       STR_ALIENS_ONLY
     stats: &OrbitalStats
@@ -1030,6 +1043,7 @@ armors:
       - 1.0
       - 1.0
       - 0.0
+    personalLight: 6
 
   - &Krechet94SpacesuitAnchor
     type: STR_ASTRONAUT_KRECHET94_SPACESUIT_UC
@@ -1047,7 +1061,6 @@ armors:
     movementType: 0
     visibilityAtDark: 7
     visibilityAtDay: 26
-    personalLight: 10
     requires:
       STR_OLYMPUS
     stats: *EarthStats
@@ -1062,6 +1075,7 @@ armors:
       - 1.0
       - 1.0
       - 1.1
+    personalLight: 6
 
   - &KrechetMMUSpacesuitAnchor
     type: STR_ASTRONAUT_KRECHETMMU_SPACESUIT_UC
@@ -1079,7 +1093,6 @@ armors:
     movementType: 1
     visibilityAtDark: 7
     visibilityAtDay: 26
-    personalLight: 10
     requires:
       STR_ALIENS_ONLY
     stats: *OrbitalStats
@@ -1094,6 +1107,7 @@ armors:
       - 1.0
       - 1.0
       - 1.1
+    personalLight: 6
 
 manufacture:
   - name: STR_COMBAT_ARMOR_UC

--- a/Ruleset/Tanks_UNEXCOM.rul
+++ b/Ruleset/Tanks_UNEXCOM.rul
@@ -683,6 +683,8 @@ armors:
      - 0.4 # Acid
      - 0.0 # Smoke
     loftempsSet: [ 92, 89, 90, 91 ]
+    personalLight: 6
+
 #####################################
 ####### M551 SHERIDAN ###############
 #####################################
@@ -714,6 +716,8 @@ armors:
      - 0.4 # Acid
      - 0.0 # Smoke
     loftempsSet: [ 92, 89, 90, 91 ]
+    personalLight: 6
+
 #####################################
 ####### BMD-1 AIRBORNE IFV ##########
 #####################################
@@ -744,7 +748,9 @@ armors:
      - 0.0 # Melee
      - 0.4 # Acid
      - 0.0 # Smoke
-    loftempsSet: [ 92, 89, 90, 91 ]
+    loftempsSet: [ 92, 89, 90, 91 ]#
+    personalLight: 6
+
 #####################################
 ########## ALVIS SALADIN AC #############
 #####################################
@@ -776,6 +782,8 @@ armors:
      - 0.4 # Acid
      - 0.0 # Smoke
     loftempsSet: [ 92, 89, 90, 91 ]
+    personalLight: 6
+
 #####################################
 ####### LEGIONNAIRE LASER TANK ###########
 #####################################
@@ -807,6 +815,7 @@ armors:
      - 0.4 # Acid
      - 0.0 # Smoke
     loftempsSet: [ 92, 89, 90, 91 ]
+    personalLight: 6
 
 extraSprites:
   - type: FERRET.PCK


### PR DESCRIPTION
When not pressing L, your units emit a light which allows the enemies to use their day viewing range instead of the night one